### PR TITLE
Fixed image centering for news

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -297,9 +297,6 @@ a.selected {
     animation: border-pulsate 1.0s infinite;
 }
 .news-image {
-	display: block;
-	margin-left: auto;
-	margin-right: auto;
 	max-height: 169px;
 	vertical-align: middle;
 	width: 254px;
@@ -410,4 +407,12 @@ a.selected {
 	font-size: 13.5px;
 	width: 47%;
 	height: 25px;
+}
+.news-image-wrapper {
+	align-items: center;
+	display: flex;
+	height: 169px;
+	line-height: 115px;
+	text-align: center;
+	width: 260px;
 }

--- a/js/dns.js
+++ b/js/dns.js
@@ -257,7 +257,7 @@ function loadNews(type) {
 					news_image = data[i].image;
 					// Prepare each news item
 					// <div class="ignore"> is for HTML parsing
-					newsBox = '<div class="ignore"><div class="news-item" id="news'+news_id+'" onclick="showNews(this.id)"><img class="news-image" src="'+newsImageURL+news_image+'" height="169"><div class="news-title"><span>'+news_title+'</span></div></div></div>';
+					newsBox = '<div class="ignore"><div class="news-item" id="news'+news_id+'" onclick="showNews(this.id)"><div class="news-image-wrapper"><img class="news-image" src="'+newsImageURL+news_image+'"></div><div class="news-title"><span>'+news_title+'</span></div></div></div>';
 					
 					// Add the gamepad navigation elements
 					// Not sure how to annotate this as it's a bit confusing


### PR DESCRIPTION
Small but important change, should stop the images in the news previews from being stretched